### PR TITLE
Add virtus model inference function for deepfake detection

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -4,34 +4,25 @@
 models/
 ├── image/
 │   ├── notebooks/
-│   │   └── Virtus.ipynb     # Jupyter notebook for training/fine-tuning
-│   │
-│   ├── datasets/
-│   │   ├── test/
-│   │   ├── train/
-│   │   └── validation/
-│   │
-│   ├── outputs/
-│   │   ├── Virtus.pt                   # Trained model checkpoint (PyTorch format)
-│   │   └── metadata.json               # Info: model arch, accuracy, dataset used, etc.
+│   │   └── Virtus.ipynb                # Jupyter notebook for fine-tuning image model
 │   │
 │   ├── scripts/
+│   │   ├── model.py                    # Handles virtus's prediction pipeline
 │   │   └── train.py                    # CLI-style training script
 │   │
 │   └── README.md                       # Image model-specific notes
-
+│
 ├── video/
 │   ├── notebooks/
 │   │   └── Scarlet.ipynb              # Jupyter notebook for fine-tuning video model
 │   │
-│   ├── datasets/
-│   │
 │   ├── outputs/
-│   │   ├── Scarlet.pt                  # Trained model checkpoint
+│   │   ├── classification_report.txt   # Classification report for model evaluation
+│   │   ├── confusion_matrix.png        # Confusion matrix for model evaluation
 │   │   └── metrics.json                # Evaluation metrics (AUC, F1, etc.)
 │   │
 │   ├── scripts/
-│   │   └── train.py                    # (Optional) Video training CLI
+│   │   └── model.py                    # Handles scarlet's prediction pipeline
 │   │
 │   └── README.md                       # Video model-specific documentation
 
@@ -39,7 +30,7 @@ models/
 │   ├── preprocessing.py                # Shared preprocessing for both image/video
 │   ├── augmentation.py                 # Augmentations used in training pipelines
 │   └── __init__.py
-
-└── README.md                           # Top-level explanation of model types and usage
+│
+└── README.md
 
 ```

--- a/models/image/scripts/model.py
+++ b/models/image/scripts/model.py
@@ -1,0 +1,34 @@
+from PIL import Image
+import torch
+from torchvision import transforms
+from transformers import AutoModelForImageClassification, AutoFeatureExtractor
+import torch.nn.functional as F
+
+
+MODEL_PATH = "agasta/virtus"  # https://huggingface.co/agasta/virtus
+
+# Load model and preprocessing pipeline once & cache it to ~/.cache/huggingface/transformers
+model = AutoModelForImageClassification.from_pretrained(MODEL_PATH) # https://huggingface.co/docs/transformers/en/model_doc/auto
+extractor = AutoFeatureExtractor.from_pretrained(MODEL_PATH)
+model.eval()
+
+def virtus(pil_image: Image.Image) -> tuple[str, float]:
+    """
+    Analyze a PIL image and return label and confidence.
+
+    Returns:
+        label (str): "fake" or "real"
+        confidence (float): confidence score in percentage (0–100)
+    """
+    inputs = extractor(images=pil_image, return_tensors="pt")
+
+    with torch.no_grad():
+        outputs = model(**inputs)
+        logits = outputs.logits
+        probs = F.softmax(logits, dim=1)
+
+    confidence, predicted_class = torch.max(probs, dim=1)
+    label = model.config.id2label[predicted_class.item()]
+    confidence_percent = round(confidence.item() * 100, 2)
+
+    return label.lower(), confidence_percent


### PR DESCRIPTION
This PR adds the virtus function located in image/scripts/model.py, which performs deepfake image classification using the fine-tuned agasta/virtus model from Hugging Face.

**Usage Example (in Jupyter):**
```python
from PIL import Image
from model import virtus

img = Image.open("test.png").convert("RGB")
label, confidence = virtus(img)
print(label, confidence)
```
